### PR TITLE
Version check can be disabled in LoginCredentials

### DIFF
--- a/src/main/java/omero/gateway/Gateway.java
+++ b/src/main/java/omero/gateway/Gateway.java
@@ -1140,7 +1140,8 @@ public class Gateway implements AutoCloseable {
             IConfigPrx conf = entryEncrypted.getConfigService();
             String serverVersion = conf.getVersion();
             if (StringUtils.isNotEmpty(clientVersion)
-                    && StringUtils.isNotEmpty(serverVersion)) {
+                    && StringUtils.isNotEmpty(serverVersion)
+                    && cred.getCheckVersion()) {
                 String[] vc = clientVersion.split("\\.");
                 String[] vs = serverVersion.split("\\.");
                 if (!vc[0].equals(vs[0]) || !vc[1].equals(vs[1]))

--- a/src/main/java/omero/gateway/LoginCredentials.java
+++ b/src/main/java/omero/gateway/LoginCredentials.java
@@ -60,6 +60,9 @@ public class LoginCredentials {
     /** The connection argument.*/
     private ImmutableList<String> args;
 
+    /** Whether to check the client-server versions */
+    private boolean checkVersion = true;
+
     /**
      * Creates a new instance
      */
@@ -229,6 +232,23 @@ public class LoginCredentials {
      */
     public void setGroupID(long groupID) {
         this.groupID = groupID;
+    }
+
+    /**
+     * Returns whether the version check is enabled
+     * @return whether the version check is enabled
+     */
+    public boolean getCheckVersion() {
+        return this.checkVersion;
+    }
+
+    /**
+     * Enable/Disable version check
+     *
+     * @param checkVersion Whether to check the client and server versions are compatible
+     */
+    public void setCheckVersion(boolean checkVersion) {
+        this.checkVersion = checkVersion;
     }
 
 }


### PR DESCRIPTION
Testing: Add `cred.setCheckVersion(false);` after https://github.com/ome/minimal-omero-client/blob/4d17ab69710b582be8269cee31345729078f1d02/src/main/java/com/example/SimpleConnection.java#L71 and try and connect to a 5.5 server from a 5.4.10 minimal-omero-client.