### PR TITLE
Exclude server dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,6 @@ dependencies {
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.4")
     testCompile("org.testng:testng:6.9.8")
-    // Re-activate from transitive excludes
-    //implementation("org.apache.commons:commons-collections4:4.1")
-    implementation("commons-collections:commons-collections:3.2.2")
-    implementation("commons-lang:commons-lang:2.6")
-
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,7 @@
 plugins {
     id 'java-library'
     id "org.openmicroscopy.project" version "5.5.0-m5"
-    id "application"
 }
-
-mainClassName = "omero.gateway.Gateway"
 
 group = "org.openmicroscopy"
 version = "5.5.0-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,7 @@ repositories {
 
 dependencies {
     api("org.openmicroscopy:omero-blitz:5.5.0-m7")
-    api("ome:formats-api:5.9.2") {
-        exclude group: "org.perf4j", module: "perf4j"
-    }
+
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.4")
     testCompile("org.testng:testng:6.9.8")
@@ -27,19 +25,17 @@ dependencies {
     //implementation("org.apache.commons:commons-collections4:4.1")
     implementation("commons-collections:commons-collections:3.2.2")
     implementation("commons-lang:commons-lang:2.6")
+
 }
 
 configurations.all {
     // resolutionStrategy.cacheChangingModulesFor 0, 'minutes'
-    exclude group: 'OME'
     exclude group: 'antlr'
     exclude group: 'asm'
     exclude group: 'backport-util-concurrent'
     exclude group: 'batik'
     exclude group: 'cglib'
     exclude group: 'com.codahale.metrics'
-    exclude group: 'com.drewnoakes'
-    exclude group: 'com.esotericsoftware.kryo'
     exclude group: 'com.jamonapi'
     exclude group: 'com.github.marcus-nl.btm'
     exclude group: 'com.mortennobel'
@@ -47,34 +43,23 @@ configurations.all {
     exclude group: 'commons-codec'
     exclude group: 'commons-pool'
     exclude group: 'dom4j'
-    exclude group: 'edu.ucar'
     exclude group: 'freemarker'
     exclude group: 'geronimo-spec'
     exclude group: 'gnu.getopt'
     exclude group: 'org.javassist'
     exclude group: 'javax.jts'
-    exclude group: 'joda-time'
     exclude group: 'net.sf.ehcache'
-    exclude group: 'ome', module: 'formats-gpl'
-    exclude group: 'ome', module: 'jai_imageio'
-    exclude group: 'ome', module: 'lwf-stubs'
-    exclude group: 'ome', module: 'turbojpeg'
     exclude group: 'org.apache.lucene'
     exclude group: 'org.apache.httpcomponents'
     exclude group: 'org.codehaus.btm'
     exclude group: 'org.hibernate'
     exclude group: 'org.hibernate.javax.persistence'
-    exclude group: 'org.ini4j'
     exclude group: "org.postgresql"
-    exclude group: 'org.scijava'
     exclude group: "org.springframework"
     exclude group: "org.springframework.security"
     exclude group: 'org.subethamail'
     exclude group: 'org.apache.pdfbox'
     exclude group: 'org.quartz-scheduler'
-    exclude group: 'xerces'
-    exclude group: 'xalan'
-    exclude group: 'xml-apis'
     exclude group: 'org.apache.xmlgraphics'
     exclude group: 'com.zeroc', module: 'ice-db'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     //implementation("org.apache.commons:commons-collections4:4.1")
     implementation("commons-collections:commons-collections:3.2.2")
     implementation("commons-lang:commons-lang:2.6")
-    implementation("com.google.guava:guava:17.0")
 }
 
 configurations.all {
@@ -42,7 +41,9 @@ configurations.all {
     exclude group: 'com.drewnoakes'
     exclude group: 'com.esotericsoftware.kryo'
     exclude group: 'com.jamonapi'
+    exclude group: 'com.github.marcus-nl.btm'
     exclude group: 'com.mortennobel'
+    exclude group: 'com.sun.mail'
     exclude group: 'commons-codec'
     exclude group: 'commons-pool'
     exclude group: 'dom4j'
@@ -50,7 +51,7 @@ configurations.all {
     exclude group: 'freemarker'
     exclude group: 'geronimo-spec'
     exclude group: 'gnu.getopt'
-    exclude group: 'javassist'
+    exclude group: 'org.javassist'
     exclude group: 'javax.jts'
     exclude group: 'joda-time'
     exclude group: 'net.sf.ehcache'
@@ -64,14 +65,18 @@ configurations.all {
     exclude group: 'org.hibernate'
     exclude group: 'org.hibernate.javax.persistence'
     exclude group: 'org.ini4j'
+    exclude group: "org.postgresql"
     exclude group: 'org.scijava'
+    exclude group: "org.springframework"
+    exclude group: "org.springframework.security"
     exclude group: 'org.subethamail'
-    exclude group: 'pdfbox'
-    exclude group: 'quartz'
+    exclude group: 'org.apache.pdfbox'
+    exclude group: 'org.quartz-scheduler'
     exclude group: 'xerces'
     exclude group: 'xalan'
     exclude group: 'xml-apis'
-    exclude group: 'zeroc', module: 'ice-db'
+    exclude group: 'org.apache.xmlgraphics'
+    exclude group: 'com.zeroc', module: 'ice-db'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,10 @@
 plugins {
     id 'java-library'
     id "org.openmicroscopy.project" version "5.5.0-m5"
+    id "application"
 }
+
+mainClassName = "omero.gateway.Gateway"
 
 group = "org.openmicroscopy"
 version = "5.5.0-SNAPSHOT"
@@ -17,6 +20,55 @@ dependencies {
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.4")
     testCompile("org.testng:testng:6.9.8")
+    // Re-activate from transitive excludes
+    //implementation("org.apache.commons:commons-collections4:4.1")
+    implementation("commons-collections:commons-collections:3.2.2")
+    implementation("commons-lang:commons-lang:2.6")
+    implementation("com.google.guava:guava:17.0")
+}
+
+configurations.all {
+    // resolutionStrategy.cacheChangingModulesFor 0, 'minutes'
+    exclude group: 'OME'
+    exclude group: 'antlr'
+    exclude group: 'asm'
+    exclude group: 'backport-util-concurrent'
+    exclude group: 'batik'
+    exclude group: 'cglib'
+    exclude group: 'com.codahale.metrics'
+    exclude group: 'com.drewnoakes'
+    exclude group: 'com.esotericsoftware.kryo'
+    exclude group: 'com.jamonapi'
+    exclude group: 'com.mortennobel'
+    exclude group: 'commons-codec'
+    exclude group: 'commons-pool'
+    exclude group: 'dom4j'
+    exclude group: 'edu.ucar'
+    exclude group: 'freemarker'
+    exclude group: 'geronimo-spec'
+    exclude group: 'gnu.getopt'
+    exclude group: 'javassist'
+    exclude group: 'javax.jts'
+    exclude group: 'joda-time'
+    exclude group: 'net.sf.ehcache'
+    exclude group: 'ome', module: 'formats-gpl'
+    exclude group: 'ome', module: 'jai_imageio'
+    exclude group: 'ome', module: 'lwf-stubs'
+    exclude group: 'ome', module: 'turbojpeg'
+    exclude group: 'org.apache.lucene'
+    exclude group: 'org.apache.httpcomponents'
+    exclude group: 'org.codehaus.btm'
+    exclude group: 'org.hibernate'
+    exclude group: 'org.hibernate.javax.persistence'
+    exclude group: 'org.ini4j'
+    exclude group: 'org.scijava'
+    exclude group: 'org.subethamail'
+    exclude group: 'pdfbox'
+    exclude group: 'quartz'
+    exclude group: 'xerces'
+    exclude group: 'xalan'
+    exclude group: 'xml-apis'
+    exclude group: 'zeroc', module: 'ice-db'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ repositories {
 
 dependencies {
     api("org.openmicroscopy:omero-blitz:5.5.0-m7")
+    api("ome:formats-api:5.9.2") {
+        exclude group: "org.perf4j", module: "perf4j"
+    }
     implementation("commons-beanutils:commons-beanutils:1.9.3")
     implementation("com.zeroc:icegrid:3.6.4")
     testCompile("org.testng:testng:6.9.8")


### PR DESCRIPTION
Reduces the size of applications that depend on this
component. This is possible since the Gateway is assumed
to be client-only and therefore all the blitz server
dependencies can be filtered.

This work is migrated from the microservice work in:

https://github.com/glencoesoftware/omero-ms-core/blob/master/build.gradle

cc: @chris-allan 

To test:
* Check that insight job is green
* Check that you can log in using insight
* Check that you can import data
* Check that there is no javadoc warning