### PR TITLE
Rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+5.5.0-m5 (May 2019)
+-------------------
+
+- Bump omero-blitz version.
+
+5.5.0-m4 (May 2019)
+-------------------
+
+- Exclude server dependencies.
+
+5.5.0-m3 (April 2019)
+---------------------
+
+- Get version from package.
+
+5.5.0-m2 (April 2019)
+---------------------
+
+- Add omero-blitz dependency as api.
+
+5.5.0-m1 (April 2019)
+------------------------
+
+- Extract Java Gateway from omero-blitz.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+OMERO Java Client Library
+-------------------------
+
+[![Build Status](https://travis-ci.org/ome/omero-gateway-java.png)](http://travis-ci.org/ome/omero-gateway-java)
+
+Full developer documentation for OMERO is available from
+https://docs.openmicroscopy.org/latest/omero/developers/
+
+If you are looking for something else, please refer to the main OME website
+https://www.openmicroscopy.org

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 OMERO Java Client Library
 -------------------------
 
-[![Build Status](https://travis-ci.org/ome/omero-gateway-java.png)](http://travis-ci.org/ome/omero-gateway-java)
+[![Build Status](https://travis-ci.org/ome/omero-gateway-java.png)](https://travis-ci.org/ome/omero-gateway-java)
 
 Full developer documentation for OMERO is available from
 https://docs.openmicroscopy.org/latest/omero/developers/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
-OMERO Java Client Library
--------------------------
+# omero-gateway
+
+OMERO Java client library
 
 [![Build Status](https://travis-ci.org/ome/omero-gateway-java.png)](https://travis-ci.org/ome/omero-gateway-java)
+
+## Usage
 
 Full developer documentation for OMERO is available from
 https://docs.openmicroscopy.org/latest/omero/developers/
 
-If you are looking for something else, please refer to the main OME website
-https://www.openmicroscopy.org
+## Build from source
+
+The compilation, testing, launch, and delivery of the application are
+automated by means of a Gradle (https://gradle.org/) build file.
+In order to perform a build, all you need is
+a JDK -- version 1.8 or later.
+Clone this GitHub repository `git clone https://github.com/ome/omero-gateway-java.git`.
+Go to the directory and enter:
+
+  gradle build
+
+This will compile, build, test and create a distribution bundle.
+
+## Unit tests
+ * Run `gradle test`

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,4 +6,4 @@ pluginManagement {
     }
 }
 
-rootProject.name = 'omero-java-gateway'
+rootProject.name = 'omero-gateway'


### PR DESCRIPTION
Before the final release, there are a few cleanups that I'd like to propose:

 1. [x] add a readme. Not sure how far we want to go. Should this have a quick "getting started" section?
 2. [x] rename the jar from `omero-java-gateway` to `omero-gateway`. This would most match the planned strategy in python (`pip install omero-gateway`) and drop a tiny bit of redundancy.
 3. [ ] rename the repo. After having worked with the repo name a while now, I'd like to re-evaluate our previous decision of "omero-java-gateway" as opposed to "omero-gateway-java". `-java` is a suffix in https://github.com/ome/ome-common-java/ and that's become how we use it for differentiating between the Java and Python gateways as well. Since dropping the middle of a name to get to `omero-gateway` feels awkward, I'd propose moving to `omero-gateway-java` before 5.5.0.

see also:
 * https://github.com/openmicroscopy/openmicroscopy/pull/6028
 * https://github.com/ome/omero-insight/pull/31
 * https://github.com/ome/omero-matlab/pull/21